### PR TITLE
Feature/shortname fix

### DIFF
--- a/GoCommando.Tests/TestCommand.cs
+++ b/GoCommando.Tests/TestCommand.cs
@@ -24,10 +24,26 @@ namespace GoCommando.Tests
             Assert.That(bimseInstance.Switch, Is.EqualTo("value2"));
         }
 
+        [TestCase("-s:value2")]
+        [TestCase("-s=value2")]
+        [TestCase(@"-s""value2""")]
+        public void CanCorrectlyHandleDifferentAlternativeSwitchFormatsFoundInOneSingleTokenOnly_Shortname(string switchText)
+        {
+            var settings = new Settings();
+            var invoker = new CommandInvoker("bimse", settings, new Bimse());
+            var arguments = Go.Parse(new[] { switchText }, settings);
+
+            invoker.Invoke(arguments.Switches, EnvironmentSettings.Empty);
+
+            var bimseInstance = (Bimse)invoker.CommandInstance;
+
+            Assert.That(bimseInstance.Switch, Is.EqualTo("value2"));
+        }
+
         [Command("bimse")]
         class Bimse : ICommand
         {
-            [Parameter("switch")]
+            [Parameter("switch", shortName: "s")]
             public string Switch { get; set; }
 
             public void Run()

--- a/GoCommando/Internals/Command.cs
+++ b/GoCommando/Internals/Command.cs
@@ -223,7 +223,7 @@ namespace GoCommando.Internals
 
         static bool CanBeResolvedFromSwitches(IEnumerable<Switch> switches, Parameter p)
         {
-            return switches.Any(s => s.Key == p.Name);
+            return switches.Any(s => p.MatchesKey(s.Key));
         }
     }
 }


### PR DESCRIPTION
Could not use short-names for non-optional parameters, command invoker would report that parameters are missing.